### PR TITLE
Add Fedora support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ In addition the certificate will be imported into dotnet so that it will be used
 ## Prerequisites
 
 - dotnet-sdk (Version >= 5.0)
-- libnss3-tools (install via `sudo apt install libnss3-tools` or `sudo pacman -S nss`)
+- libnss3-tools
+    - ubuntu: `sudo apt install libnss3-tools` 
+    - arch: `sudo pacman -S nss`
+    - fedora: `sudo dnf install openssl nss-tools`
 
 ## Usage
 
@@ -27,6 +30,9 @@ Ubuntu based distributions:
 
 Arch based distributions:
 `./scripts/arch-create-dotnet-devcert`
+
+Fedora based distributions:
+`./scripts/fedora-create-dotnet-devcert`
 
 ## More info
 

--- a/scripts/fedora-create-dotnet-devcert.sh
+++ b/scripts/fedora-create-dotnet-devcert.sh
@@ -4,4 +4,4 @@
 $SUDO cp $CRTFILE "/etc/pki/ca-trust/source/anchors/"
 $SUDO update-ca-trust
 
-#cleanup
+cleanup

--- a/scripts/fedora-create-dotnet-devcert.sh
+++ b/scripts/fedora-create-dotnet-devcert.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+. ./common.sh
+
+$SUDO cp $CRTFILE "/etc/pki/ca-trust/source/anchors/"
+$SUDO update-ca-trust
+
+#cleanup


### PR DESCRIPTION
Added Fedora script with proper cert locations. This has been tested and worked for Chromium based browsers installed via RPM or flatpak. 

This does not work for Firefox however due to the error: `MOZILLA_PKIX_ERROR_CA_CERT_USED_AS_END_ENTITY`. This appears to be an issue with the cert being generated with `basicConstraints = CA:true` as found [here](https://wiki.mozilla.org/SecurityEngineering/x509Certs#Error_Codes_in_Firefox) 