### PR TITLE
Save pfx file

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -95,5 +95,4 @@ if [ "$SAVE" = 1 ]; then
    echo "Saved certificate to $HOME/$(basename $CRTFILE)"
    cp $PFXFILE $HOME
    echo "Saved certificate to $HOME/$(basename $PFXFILE)"
-
 fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -93,4 +93,7 @@ dotnet dev-certs https --clean --import $PFXFILE -p ""
 if [ "$SAVE" = 1 ]; then
    cp $CRTFILE $HOME
    echo "Saved certificate to $HOME/$(basename $CRTFILE)"
+   cp $PFXFILE $HOME
+   echo "Saved certificate to $HOME/$(basename $PFXFILE)"
+
 fi


### PR DESCRIPTION
PFX file is needed in dotnet Kestrel. It can be given through an environment variable that tells Kestrel the path to the PFX file. `ASPNETCORE_Kestrel__Certificates__Default__Path` is the variable name. That can be added to `.bashrc` or similar.